### PR TITLE
Fix an issue with the_category filter being overzealous

### DIFF
--- a/primary-taxonomy-term.php
+++ b/primary-taxonomy-term.php
@@ -143,6 +143,11 @@ function ptt_sort_primary_term ( $categories ) {
 // @TODO: extend PTT functionality to all taxonomies
 add_filter ( 'the_category', 'ptt_primary_term_class' );
 function ptt_primary_term_class ( $category_list ) {
+	// ensure this filter is only run on single posts
+	if ( ! is_single() ) {
+		return $category_list;
+	}
+	
 	global $post;
 
 	$term_id = (integer) get_post_meta ( $post->ID, '_ptt-primary-category', true );


### PR DESCRIPTION
This patches a bug in the_category filter which had a negative impact on the display of categories on the backend. The DOM manipulation rendered unwanted markup in the category meta box.

The fix is to restrict the_category filter to run only on SINGLE templates as originally intended.